### PR TITLE
Remove maven group override

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,17 +79,6 @@ pluginBundle {
     }
 }
 
-publishing {
-
-    publications {
-        register("deblibs", MavenPublication::class) {
-            setGroupId(groupId)
-            artifactId = "deblibs"
-            from(components["java"])
-        }
-    }
-}
-
 fun setupPublishingEnvironment() {
 
     val keyProperty = "gradle.publish.key"


### PR DESCRIPTION
This `PR` makes the following changes:

- This is causing the removal of gradle.plugin prefix by the Gradle Portal
Plugin System causing the artifact publishing to be approved for the
first time
