### PR TITLE
Remove `githubOwner` property and replace it with just `githubRepo`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 build/
 .idea/
 !gradle-wrapper.jar
+*.iml
+local.properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Removed
+-  Removed `githubOwner` property and replaced it with just `githubRepo` which means you have to add
+the owner as well. So now `githubRepo` value would be `hellofresh/deblibs-gradle-plugin`
+
 ### Added
 - Unit tests
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ If you don't configure the default will be used which are blank values. This wil
 ```groovy
 deblibs {
    projectName ="Project name"
-   githubOwner = "project-github-owner"
    githubRepo = "project-github-repo"
    githubToken = "github-token"
    slackToken = "slack-token"

--- a/src/main/kotlin/com/hellofresh/deblibs/DebLibsExtension.kt
+++ b/src/main/kotlin/com/hellofresh/deblibs/DebLibsExtension.kt
@@ -18,7 +18,6 @@ package com.hellofresh.deblibs
 
 open class DebLibsExtension(
     var projectName: String = "",
-    var githubOwner: String = "",
     var githubRepo: String = "",
     var githubToken: String = "",
     var slackToken: String = "",

--- a/src/main/kotlin/com/hellofresh/deblibs/DebLibsPlugin.kt
+++ b/src/main/kotlin/com/hellofresh/deblibs/DebLibsPlugin.kt
@@ -67,7 +67,6 @@ open class DebLibsPlugin : Plugin<Project> {
             afterEvaluate {
                 val createGithubIssue =
                     tasks.getByName(GITHUB_TASK_NAME) as CreateGithubIssueTask
-                createGithubIssue.owner = ext.githubOwner
                 createGithubIssue.repo = ext.githubRepo
                 createGithubIssue.token = ext.githubToken
 

--- a/src/main/kotlin/com/hellofresh/deblibs/github/CreateGithubIssueTask.kt
+++ b/src/main/kotlin/com/hellofresh/deblibs/github/CreateGithubIssueTask.kt
@@ -25,8 +25,6 @@ import org.gradle.api.tasks.Input
 open class CreateGithubIssueTask : BaseDefaultTask() {
 
     @Input
-    lateinit var owner: String
-    @Input
     lateinit var repo: String
     @Input
     lateinit var token: String
@@ -49,7 +47,6 @@ open class CreateGithubIssueTask : BaseDefaultTask() {
         }
         if (outDatedDependencies.isNotBlank()) {
             GithubClient(
-                owner,
                 repo,
                 token,
                 GithubIssue("Outdated Dependencies(${dependencies.size})", outDatedDependencies)

--- a/src/main/kotlin/com/hellofresh/deblibs/github/GithubClient.kt
+++ b/src/main/kotlin/com/hellofresh/deblibs/github/GithubClient.kt
@@ -29,7 +29,6 @@ import okhttp3.Response
 import java.net.HttpURLConnection
 
 class GithubClient(
-    private val owner: String,
     private val repo: String,
     private val token: String,
     private val githubIssue: GithubIssue
@@ -45,7 +44,7 @@ class GithubClient(
         val json = moshiAdapter.toJson(githubIssue)
         val requestBody = RequestBody.create(JSON, json)
         val request = createRequestHeaders(token)
-            .url("https://api.github.com/repos/$owner/$repo/issues")
+            .url("https://api.github.com/repos/$repo/issues")
             .post(requestBody)
             .build()
         var response: Response? = null
@@ -59,7 +58,7 @@ class GithubClient(
 
         if (status != HttpURLConnection.HTTP_CREATED) {
             if (status == HttpURLConnection.HTTP_NOT_FOUND) {
-                error("404 Repository with Owner: '$owner' and Name: '$repo' was not found")
+                error("404 Repository with Repo: '$repo' was not found")
             }
             error("Could not create github issue: $status ${response?.message()}\n$githubIssue")
         }

--- a/src/main/kotlin/com/hellofresh/deblibs/github/GithubClient.kt
+++ b/src/main/kotlin/com/hellofresh/deblibs/github/GithubClient.kt
@@ -58,7 +58,7 @@ class GithubClient(
 
         if (status != HttpURLConnection.HTTP_CREATED) {
             if (status == HttpURLConnection.HTTP_NOT_FOUND) {
-                error("404 Repository with Repo: '$repo' was not found")
+                error("404 Repository at '$repo' was not found")
             }
             error("Could not create github issue: $status ${response?.message()}\n$githubIssue")
         }


### PR DESCRIPTION
Fixes #28 

This `PR` makes the following changes:

- Removes `githubOwner` property and replaces it with just `githubRepo`
- Update Changelog file with the upcoming changes
- Update readme file with the upcoming changes
