### PR TITLE
Remove default slack icon URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Unit tests
 
+### Removed
+-  Removed Slack's default icon and replaced it with nothing. This means if you want an icon with the 
+bot you've to provide a URL for the icon. 
+
 ## [1.0.0] - 2018-12-11
 ### Added
 - Added support for posting report to Github as an issue.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ deblibs {
    githubRepo = "project-github-repo"
    githubToken = "github-token"
    slackToken = "slack-token"
-   slackChannel = "#slack-channel"    
+   slackChannel = "#slack-channel"
+   slackIconUrl = "url-to-an-icon-to-be-used-by-the-slack-bot"    
 }
 
 ```

--- a/src/main/kotlin/com/hellofresh/deblibs/slack/CreateSlackMessageTask.kt
+++ b/src/main/kotlin/com/hellofresh/deblibs/slack/CreateSlackMessageTask.kt
@@ -24,7 +24,6 @@ import com.hellofresh.deblibs.slack.SlackMessage.Attachment
 import com.hellofresh.deblibs.slack.SlackMessage.Attachment.Color.GREEN
 import com.hellofresh.deblibs.slack.SlackMessage.Attachment.Color.RED
 import com.hellofresh.deblibs.slack.SlackMessage.Attachment.Color.YELLOW
-import com.hellofresh.deblibs.slack.SlackMessage.Companion.DEFAULT_ICON_URL
 import org.gradle.api.tasks.Input
 
 open class CreateSlackMessageTask : BaseDefaultTask() {
@@ -62,7 +61,7 @@ open class CreateSlackMessageTask : BaseDefaultTask() {
         val attachments =
             buildMessageAttachment(dependencies.size, outDatedDependencies)
         val name = if (username.isBlank()) "DebLibs" else username
-        val icon = if (iconUrl.isBlank()) DEFAULT_ICON_URL else iconUrl
+        val icon = iconUrl
         SlackClient(
             token,
             SlackMessage(

--- a/src/main/kotlin/com/hellofresh/deblibs/slack/SlackMessage.kt
+++ b/src/main/kotlin/com/hellofresh/deblibs/slack/SlackMessage.kt
@@ -22,7 +22,7 @@ import org.gradle.internal.time.Time
 data class SlackMessage(
     val username: String,
     val channel: String,
-    @Json(name = "icon_url") val iconUrl: String = DEFAULT_ICON_URL,
+    @Json(name = "icon_url") val iconUrl: String = "",
     val attachments: List<Attachment>
 ) {
     data class Attachment(
@@ -41,8 +41,6 @@ data class SlackMessage(
     }
 
     companion object {
-        const val DEFAULT_ICON_URL =
-            "https://avatars.slack-edge.com/2018-06-12/380095389394_a485f66ceffe05c1e6d4_192.png"
         const val ROUNDING_NUMBER = 1000
     }
 }


### PR DESCRIPTION
Fixes #30 

This `PR` makes the following changes:

- Replaced default slack icon URL with empty string