### PR TITLE
Fix wrong Gradle Plugin website URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## Changed
+- Fixed wrong Gradle plugin website URL.
+
 ### Removed
 -  Removed `githubOwner` property and replaced it with just `githubRepo` which means you have to add
 the owner as well. So now `githubRepo` value would be `hellofresh/deblibs-gradle-plugin`
 
-### Added
-- Unit tests
-
-### Removed
 -  Removed Slack's default icon and replaced it with nothing. This means if you want an icon with the 
-bot you've to provide a URL for the icon. 
+bot you've to provide a URL for the icon.
+
+### Added
+- Unit tests.
+
 
 ## [1.0.0] - 2018-12-11
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ gradlePlugin {
 }
 
 pluginBundle {
-    website = "https://plugins.gradle.org/plugin/com.hellofresh.deblibs"
+    website = "https://plugins.gradle.org/plugin/com.hellofresh.gradle.deblibs"
     vcsUrl = "https://github.com/hellofresh/deblibs-gradle-plugin"
     tags = listOf(
         "kotlin",


### PR DESCRIPTION
This `PR` makes the following changes:

- Use `https://plugins.gradle.org/plugin/com.hellofresh.gradle.deblibs` as the website URL. When making a release the publishing fails.
