### PR TITLE
Update Changelog doc with version diff links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+[Unreleased]:
+
+## Updated
+- Updated CHANGELOG.md footer links with unreleased info
+
 ## [2.1.0] - 2020-02-06
 
 ### Updated
@@ -33,6 +38,7 @@ bot you have to provide a URL for the icon.
 - Added support for posting report to Github as an issue.
 - Added support for posting report to Slack as a message.
 
-[Unreleased]: https://github.com/hellofresh/deblibs-gradle-plugin/compare/2.0.0...HEAD
+[Unreleased]: https://github.com/hellofresh/deblibs-gradle-plugin/compare/2.1.0...HEAD
+[2.1.0]: https://github.com/hellofresh/deblibs-gradle-plugin/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/hellofresh/deblibs-gradle-plugin/compare/1.0.0...2.0.0
 [1.0.0]: https://github.com/hellofresh/deblibs-gradle-plugin/compare/04fd121...1.0.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,8 +9,9 @@ Releasing
  6. `git tag -a X.Y.Z -m "Version X.Y.Z"`
  7. `git push && git push --tags`
  8. Update `version` value in `build.gradle.kts` to the next SNAPSHOT version.
- 9. `git commit -am "Prepare next development version."`
- 10. `git push`
+ 9. Update version links at the bottom of the `CHANGELOG.md` file.
+ 10. `git commit -am "Prepare next development version."`
+ 11. `git push`
 
  *Note:* To get the changelog messages from the commit history, issue.
 


### PR DESCRIPTION
Fixes #44 

This `PR` makes the following changes:

- Updated CHANGELOG.md footer links with unreleased info
