### PR TITLE
Use moshi-kotlin artifact for reflection based de/serialization

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,6 +105,7 @@ dependencies {
     implementation("com.github.ben-manes:gradle-versions-plugin:0.27.0")
     implementation("com.squareup.okhttp3:okhttp:4.3.1")
     implementation("com.squareup.moshi:moshi:1.9.2")
+    implementation("com.squareup.moshi:moshi-kotlin:1.9.2")
     implementation("com.squareup.okio:okio:2.4.3")
     implementation(kotlin("stdlib"))
 }

--- a/src/main/kotlin/com/hellofresh/deblibs/Adapters.kt
+++ b/src/main/kotlin/com/hellofresh/deblibs/Adapters.kt
@@ -18,10 +18,11 @@ package com.hellofresh.deblibs
 
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 
 object Adapters {
 
-    val moshi = Moshi.Builder().build()!!
+    val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
     val DependencyGraph: JsonAdapter<DependencyGraph> = adapter()
     inline fun <reified T> adapter(): JsonAdapter<T> = moshi.adapter(T::class.java)
 }


### PR DESCRIPTION
Fixes #50 

This `PR` makes the following changes:

- Adds `moshi-kotlin` artifact 
- Add `KotlinJsonAdapterFactory()` to create a build
